### PR TITLE
[Change] Added support for CF Environment Tags

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
 }
 
 group 'me.hypherionmc.modutils'
-version '1.0.6'
+version '1.0.7'
 java.toolchain.languageVersion = JavaLanguageVersion.of(8)
 
 configurations {

--- a/src/main/java/me/hypherionmc/curseupload/requests/GameVersions.java
+++ b/src/main/java/me/hypherionmc/curseupload/requests/GameVersions.java
@@ -70,7 +70,7 @@ public class GameVersions {
             versionReader.close();
 
             for (VersionType type : types) {
-                if (type.slug().startsWith("minecraft") || type.slug().equals("java") || type.slug().equals("modloader")) {
+                if (type.slug().startsWith("minecraft") || type.slug().equals("java") || type.slug().equals("environment") || type.slug().equals("modloader")) {
                     validVersionTypes.add(type.id());
                 }
             }

--- a/src/test/java/CurseUploadTest.java
+++ b/src/test/java/CurseUploadTest.java
@@ -15,6 +15,7 @@ public class CurseUploadTest {
         artifact.changelog("This is a sample changelog");
         artifact.changelogType(CurseChangelogType.TEXT);
         artifact.addGameVersion("1.19.2").addGameVersion("1.16.5");
+        artifact.addGameVersion("client").addGameVersion("server");
         artifact.modLoader("forge").modLoader("fabric");
         artifact.displayName("This is a sample file");
         artifact.releaseType(CurseReleaseType.BETA);


### PR DESCRIPTION
- As of April 2023, CurseForge has implemented Environment Tags for `Client` and `Server` (Although you can also tick both).
- Related to discussions with wolfgang, these changes are related to some more server-friendly features coming down the road, and it is recommended for Mod Creators to tag their mods appropriately

- Test Case has also been updated to display the two usages as well