### PR TITLE
[Change] replace `getLogger` with `log` - support custom logging function

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 # Plugin Information
 version_major=1
-version_minor=0
-version_patch=13
+version_minor=1
+version_patch=0
 maven_group=me.hypherionmc.modutils
 
 # Dependencies

--- a/src/main/java/me/hypherionmc/curseupload/CurseUploadApi.java
+++ b/src/main/java/me/hypherionmc/curseupload/CurseUploadApi.java
@@ -26,10 +26,14 @@ package me.hypherionmc.curseupload;
 import me.hypherionmc.curseupload.constants.GameType;
 import me.hypherionmc.curseupload.requests.CurseArtifact;
 import me.hypherionmc.curseupload.requests.GameVersions;
+import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.slf4j.helpers.FormattingTuple;
+import org.slf4j.helpers.MessageFormatter;
 
 import java.io.FileNotFoundException;
+import java.util.function.Consumer;
 
 /**
  * @author HypherionSA
@@ -39,7 +43,10 @@ public class CurseUploadApi {
 
     // A static reference to an instance of this class. Used internally
     public static CurseUploadApi INSTANCE;
-    private final Logger logger;
+
+    // Either logger or logConsumer must be non-null
+    private final @Nullable Logger logger;
+    private final @Nullable Consumer<String> logConsumer;
 
     // Upload API Token. Required
     private final String apiKey;
@@ -66,8 +73,22 @@ public class CurseUploadApi {
      * @param logger SLF4J Logger to use instead of the default one
      */
     public CurseUploadApi(String apiKey, Logger logger) {
+        this(apiKey, null, logger);
+    }
+
+    /**
+     * Create a new API Client
+     * @param apiKey API Key REQUIRED to use any of the upload endpoints
+     * @param logger a logging {@link Consumer function} to use instead of the default {@link Logger logger}
+     */
+    public CurseUploadApi(String apiKey, Consumer<String> logger) {
+        this(apiKey, logger, null);
+    }
+
+    private CurseUploadApi(String apiKey, @Nullable Consumer<String> logConsumer, @Nullable Logger logger) {
         this.apiKey = apiKey;
         this.logger = logger;
+        this.logConsumer = logConsumer;
         this.gameVersions = new GameVersions();
         INSTANCE = this;
 
@@ -122,7 +143,32 @@ public class CurseUploadApi {
         });
     }
 
+    /**
+     * @deprecated replace with {@link #log}
+     */
+    @Deprecated
     public Logger getLogger() {
-        return logger;
+        if (logger != null) return logger;
+        String detail = (logConsumer == null) ? ""
+                : " " + getClass().getSimpleName()
+                + " was configured with a plain logging function";
+        throw new IllegalStateException("No logger available." + detail);
+    }
+
+    public void log(String message) {
+        if (logger != null) logger.error(message);
+        if (logConsumer != null) logConsumer.accept(message);
+    }
+
+    public void log(String format, Object ...args) {
+        if (logger != null) logger.error(format, args);
+        if (logConsumer != null) {
+            FormattingTuple fmt = MessageFormatter.arrayFormat(format, args);
+            Throwable throwable = fmt.getThrowable();
+            String message = (throwable == null)
+                    ? fmt.getMessage()
+                    : fmt.getMessage() + ": " + throwable.getLocalizedMessage();
+            logConsumer.accept(message);
+        }
     }
 }

--- a/src/main/java/me/hypherionmc/curseupload/requests/CurseArtifact.java
+++ b/src/main/java/me/hypherionmc/curseupload/requests/CurseArtifact.java
@@ -340,7 +340,7 @@ public class CurseArtifact {
                     final InputStreamReader reader = new InputStreamReader(response.getEntity().getContent());
                     this.curseFileId = HTTPUtils.gson.fromJson(reader, ResponseSuccess.class).id;
                     reader.close();
-                    CurseUploadApi.INSTANCE.getLogger().error("Successfully uploaded artifact {} with ID {}", this.artifact.getName(), this.curseFileId);
+                    CurseUploadApi.INSTANCE.log("Successfully uploaded artifact {} with ID {}", this.artifact.getName(), this.curseFileId);
                 } else {
                     int errorCode = response.getStatusLine().getStatusCode();
                     String errorMessage = response.getStatusLine().getReasonPhrase();
@@ -353,10 +353,10 @@ public class CurseArtifact {
                         errorCode = error.errorCode;
                         errorMessage = error.errorMessage;
                     }
-                    CurseUploadApi.INSTANCE.getLogger().error("Failed to Upload artifact to CurseForge. Code: {}, Error: {}", errorCode, errorMessage);
+                    CurseUploadApi.INSTANCE.log("Failed to Upload artifact to CurseForge. Code: {}, Error: {}", errorCode, errorMessage);
                 }
             } catch (Exception e) {
-                CurseUploadApi.INSTANCE.getLogger().error("Failed to Upload artifact to CurseForge.", e);
+                CurseUploadApi.INSTANCE.log("Failed to Upload artifact to CurseForge.", e);
             }
         } else {
             // Do not upload the file. Instead, write the JSON that will be sent to the console
@@ -364,7 +364,7 @@ public class CurseArtifact {
             object.add("metadata", HTTPUtils.gson.toJsonTree(this.writeMetaData()));
             object.addProperty("file", this.artifact.getName());
 
-            CurseUploadApi.INSTANCE.getLogger().error(HTTPUtils.gson.toJson(object));
+            CurseUploadApi.INSTANCE.log(HTTPUtils.gson.toJson(object));
         }
     }
 

--- a/src/main/java/me/hypherionmc/curseupload/requests/GameVersions.java
+++ b/src/main/java/me/hypherionmc/curseupload/requests/GameVersions.java
@@ -84,7 +84,7 @@ public class GameVersions {
                 }
             }
         } catch (Exception e) {
-            CurseUploadApi.INSTANCE.getLogger().error("Failed to fetch CurseForge Versions", e);
+            CurseUploadApi.INSTANCE.log("Failed to fetch CurseForge Versions", e);
         }
     }
 


### PR DESCRIPTION
One way to solve MinecraftFreecam/Publisher#12 is to allow injecting a "logging function" instead of a full-blown SLF4J `Logger`. This is acceptable, because CurseUpload4J always logs to `ERROR` anyway, so the only logging "features" being used are message formatting.

An alternative/additional solution would be to define a `CurseUploadApi.logLevel` field (default to `ERROR`) and use `log(level, "")` instead of `error("")`. That'd also solve MinecraftFreecam/Publisher#12, but it'd mean I personally still need a `Slf4jAdapter`.

This deprecates `CurseUploadApi.getLogger()` and replaces it with `CurseUploadApi.log()`. `CurseUploadApi.getLogger()` still works if an SLF4J `logger` was provided. If `logger` is null, `getLogger()` now throws an `IllegalStateException`.
