### PR TITLE
[CHANGE] Sort GameVersions set & throw custom exception

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 # Plugin Information
 version_major=1
 version_minor=1
-version_patch=0
+version_patch=1
 maven_group=me.hypherionmc.modutils
 
 # Dependencies

--- a/src/main/java/me/hypherionmc/curseupload/errors/InvalidCurseVersionException.java
+++ b/src/main/java/me/hypherionmc/curseupload/errors/InvalidCurseVersionException.java
@@ -1,0 +1,78 @@
+/*
+ * This file is part of CurseUpload4J, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2023 HypherionSA and Contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package me.hypherionmc.curseupload.errors;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static java.util.Collections.unmodifiableList;
+
+/**
+ * @author MattSturgeon
+ * Thrown when using Minecraft Versions that are not supported by Curseforge
+ */
+public class InvalidCurseVersionException extends IllegalArgumentException {
+    private final List<String> invalidVersions;
+    private final List<String> validVersions;
+
+    public static InvalidCurseVersionException of(Collection<String> invalidVersions, Collection<String> validVersions) {
+        List<String> invalid = invalidVersions.stream().sorted().collect(Collectors.toList());
+        List<String> valid = validVersions.stream().sorted().collect(Collectors.toList());
+        return new InvalidCurseVersionException(invalid, valid);
+    }
+
+    private static String message(List<String> invalid, List<String> valid) {
+        StringBuilder msg = new StringBuilder();
+        switch (invalid.size()) {
+            case 0: break;
+            case 1:
+                String v = invalid.stream().findFirst().orElse(null);
+                msg.append(v).append(" is not a valid game version. ");
+                break;
+            default:
+                msg.append("Invalid game versions: ");
+                msg.append(String.join(", ", invalid));
+                msg.append(". ");
+                break;
+        }
+        msg.append("Valid versions are: ");
+        msg.append(String.join(", ", valid));
+        return msg.toString();
+    }
+
+    private InvalidCurseVersionException(List<String> invalidVersions, List<String> validVersions) {
+        super(message(invalidVersions, validVersions));
+        this.invalidVersions = unmodifiableList(invalidVersions);
+        this.validVersions = unmodifiableList(validVersions);
+    }
+
+    public final List<String> getInvalidVersions() {
+        return invalidVersions;
+    }
+
+    public final List<String> getValidVersions() {
+        return validVersions;
+    }
+}

--- a/src/main/java/me/hypherionmc/curseupload/requests/GameVersions.java
+++ b/src/main/java/me/hypherionmc/curseupload/requests/GameVersions.java
@@ -34,6 +34,7 @@ import me.hypherionmc.curseupload.schema.versions.VersionType;
 import me.hypherionmc.curseupload.util.HTTPUtils;
 
 import java.io.Reader;
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -80,11 +81,10 @@ public class GameVersions {
                 versions = HTTPUtils.gson.fromJson(gameVersionJson, Version[].class);
             }
 
-            for (Version version : versions) {
-                if (validVersionTypes.contains(version.type())) {
-                    version.versions().forEach(ver -> gameVersions.put(ver.name().toLowerCase(), ver.id()));
-                }
-            }
+            Arrays.stream(versions)
+                    .filter(version -> validVersionTypes.contains(version.type()))
+                    .flatMap(version -> version.versions().stream())
+                    .forEach(data -> gameVersions.put(data.name().toLowerCase(), data.id()));
         } catch (Exception e) {
             CurseUploadApi.INSTANCE.log("Failed to fetch CurseForge Versions", e);
         }

--- a/src/main/java/me/hypherionmc/curseupload/requests/GameVersions.java
+++ b/src/main/java/me/hypherionmc/curseupload/requests/GameVersions.java
@@ -64,9 +64,10 @@ public class GameVersions {
         try {
             TLongSet validVersionTypes = new TLongHashSet();
 
-            Reader versionReader = HTTPUtils.fetch(gameType.versionTypesEndpoint());
-            VersionType[] types = HTTPUtils.gson.fromJson(versionReader, VersionType[].class);
-            versionReader.close();
+            VersionType[] types;
+            try (Reader versionReader = HTTPUtils.fetch(gameType.versionTypesEndpoint())) {
+                types = HTTPUtils.gson.fromJson(versionReader, VersionType[].class);
+            }
 
             for (VersionType type : types) {
                 if (type.slug().startsWith("minecraft") || type.slug().equals("java") || type.slug().equals("environment") || type.slug().equals("modloader") || type.slug().equals("game")) {
@@ -74,9 +75,10 @@ public class GameVersions {
                 }
             }
 
-            Reader gameVersionJson = HTTPUtils.fetch(gameType.versionsEndpoint());
-            Version[] versions = HTTPUtils.gson.fromJson(gameVersionJson, Version[].class);
-            gameVersionJson.close();
+            Version[] versions;
+            try (Reader gameVersionJson = HTTPUtils.fetch(gameType.versionsEndpoint())) {
+                versions = HTTPUtils.gson.fromJson(gameVersionJson, Version[].class);
+            }
 
             for (Version version : versions) {
                 if (validVersionTypes.contains(version.type())) {

--- a/src/main/java/me/hypherionmc/curseupload/requests/GameVersions.java
+++ b/src/main/java/me/hypherionmc/curseupload/requests/GameVersions.java
@@ -29,6 +29,7 @@ import gnu.trove.set.TLongSet;
 import gnu.trove.set.hash.TLongHashSet;
 import me.hypherionmc.curseupload.CurseUploadApi;
 import me.hypherionmc.curseupload.constants.GameType;
+import me.hypherionmc.curseupload.errors.InvalidCurseVersionException;
 import me.hypherionmc.curseupload.schema.versions.Version;
 import me.hypherionmc.curseupload.schema.versions.VersionType;
 import me.hypherionmc.curseupload.util.HTTPUtils;
@@ -37,7 +38,6 @@ import java.io.Reader;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 /**
  * @author HypherionSA
@@ -96,19 +96,20 @@ public class GameVersions {
      * Used when sending a request to the API
      * @param objects The list of game versions to check
      * @return The list of game versions ID's if no error occurred
+     * @throws InvalidCurseVersionException If any game versions are not supported by CurseForge
      */
     public Set<Long> resolveGameVersion(Set<String> objects) {
-        Set<Long> set = new HashSet<>();
+        Set<Long> ids = new HashSet<>();
+        Set<String> invalid = new HashSet<>();
 
         objects.forEach(obj -> {
-            long id = gameVersions.get(obj.toLowerCase());
-            if (id == 0) {
-                String versions = gameVersions.keySet().stream().sorted().collect(Collectors.joining(", "));
-                throw new IllegalArgumentException(obj + " is not a valid game version. Valid versions are: " + versions);
-            }
-            set.add(id);
+            String version = obj.toLowerCase();
+            long id = gameVersions.get(version);
+            if (id == 0) invalid.add(version);
+            else ids.add(id);
         });
 
-        return set;
+        if (invalid.isEmpty()) return ids;
+        else throw InvalidCurseVersionException.of(invalid, gameVersions.keySet());
     }
 }

--- a/src/main/java/me/hypherionmc/curseupload/requests/GameVersions.java
+++ b/src/main/java/me/hypherionmc/curseupload/requests/GameVersions.java
@@ -37,6 +37,7 @@ import java.io.Reader;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * @author HypherionSA
@@ -102,7 +103,8 @@ public class GameVersions {
         objects.forEach(obj -> {
             long id = gameVersions.get(obj.toLowerCase());
             if (id == 0) {
-                throw new IllegalArgumentException(obj + " is not a valid game version. Valid versions are: " + gameVersions.keySet());
+                String versions = gameVersions.keySet().stream().sorted().collect(Collectors.joining(", "));
+                throw new IllegalArgumentException(obj + " is not a valid game version. Valid versions are: " + versions);
             }
             set.add(id);
         });


### PR DESCRIPTION
As per my aside in https://github.com/firstdarkdev/CurseUpload4J/issues/3, a sorted list of valid versions is easier to digest.

~~If I understand `TObjectLongHashMap`, the map is implemented as an array so insertion order is preserved. Therefore, I opted to sort before inserting.~~ Alternatively, we could sort only when rendering the exception message.

---

EDIT: added a custom `InvalidCurseVersionException` exception for clients to catch. This provides access to the full list of invalid versions used, and the full list of valid CurseForge versions. I believe that resolves #3 as clients can now catch, filter, and retry.
